### PR TITLE
remoting: add support for running the ggml-metal support_op method in the guest

### DIFF
--- a/ggml/include/ggml-metal.h
+++ b/ggml/include/ggml-metal.h
@@ -61,6 +61,11 @@ GGML_BACKEND_API void ggml_backend_metal_capture_next_compute(ggml_backend_t bac
 
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_metal_reg(void);
 
+GGML_BACKEND_API void ggml_backend_metal_get_device_context(ggml_backend_dev_t dev,
+							    bool *has_simdgroup_mm,
+							    bool *has_simdgroup_reduction,
+							    bool *use_bfloat);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ggml/src/ggml-metal/ggml-metal.m
+++ b/ggml/src/ggml-metal/ggml-metal.m
@@ -6068,3 +6068,16 @@ ggml_backend_reg_t ggml_backend_metal_reg(void) {
 }
 
 GGML_BACKEND_DL_IMPL(ggml_backend_metal_reg)
+
+
+GGML_BACKEND_API void
+ggml_backend_metal_get_device_context(ggml_backend_dev_t dev,
+				      bool *has_simdgroup_mm,
+				      bool *has_simdgroup_reduction,
+				      bool *use_bfloat) {
+  struct ggml_backend_metal_device_context *dev_ctx = dev->context ;
+
+  *use_bfloat = dev_ctx->use_bfloat;
+  *has_simdgroup_reduction = dev_ctx->has_simdgroup_reduction;
+  *has_simdgroup_mm = dev_ctx->has_simdgroup_mm;
+}

--- a/ggml/src/ggml-remotingbackend/CMakeLists.txt
+++ b/ggml/src/ggml-remotingbackend/CMakeLists.txt
@@ -10,6 +10,7 @@ ggml_add_backend_library(ggml-remotingbackend
                          backend-dispatched-device.cpp
                          backend-dispatched-buffer.cpp
                          backend-dispatched-buffer-type.cpp
+                         backend-dispatched-metal.cpp
                          backend-utils.cpp
                          shared/api_remoting.h
                          shared/apir_backend.h

--- a/ggml/src/ggml-remotingbackend/backend-dispatched-metal.cpp
+++ b/ggml/src/ggml-remotingbackend/backend-dispatched-metal.cpp
@@ -1,0 +1,40 @@
+#include <cstdint>
+#include "backend-internal.h"
+#include "backend-dispatched.h"
+
+#include "ggml-impl.h"
+#include "ggml-backend-impl.h"
+#include "ggml-backend.h"
+
+void (*ggml_backend_metal_get_device_context_fct)(ggml_backend_dev_t dev,
+						  bool *has_simdgroup_mm,
+						  bool *has_simdgroup_reduction,
+						  bool *use_bfloat) = NULL;
+
+uint32_t
+backend_metal_get_device_context(struct vn_cs_encoder *enc, struct vn_cs_decoder *dec, struct virgl_apir_context *ctx) {
+  UNUSED(ctx);
+
+  bool has_simdgroup_mm;
+  bool has_simdgroup_reduction;
+  bool use_bfloat;
+
+  uint32_t ret = 0;
+  if (ggml_backend_metal_get_device_context_fct) {
+
+    ggml_backend_metal_get_device_context_fct(dev,
+					  &has_simdgroup_mm,
+					  &has_simdgroup_reduction,
+					  &use_bfloat
+      );
+  } else {
+    ERROR("ggml_backend_metal_get_device_context not available :/");
+    ret = 1;
+  }
+
+  vn_encode_bool_t(enc, &has_simdgroup_mm);
+  vn_encode_bool_t(enc, &has_simdgroup_reduction);
+  vn_encode_bool_t(enc, &use_bfloat);
+
+  return ret;
+}

--- a/ggml/src/ggml-remotingbackend/backend-dispatched.h
+++ b/ggml/src/ggml-remotingbackend/backend-dispatched.h
@@ -46,6 +46,9 @@ uint32_t backend_buffer_free_buffer(struct vn_cs_encoder *enc, struct vn_cs_deco
 /* backend */
 uint32_t backend_graph_compute(struct vn_cs_encoder *enc, struct vn_cs_decoder *dec, struct virgl_apir_context *ctx);
 
+/* metal */
+uint32_t backend_metal_get_device_context(struct vn_cs_encoder *enc, struct vn_cs_decoder *dec, struct virgl_apir_context *ctx);
+
 static inline const char *backend_dispatch_command_name(ApirBackendCommandType type)
 {
   switch (type) {
@@ -76,6 +79,10 @@ static inline const char *backend_dispatch_command_name(ApirBackendCommandType t
 
   /* backend */
   case APIR_COMMAND_TYPE_BACKEND_GRAPH_COMPUTE: return "backend_graph_compute";
+
+  /* metal */
+  case APIR_COMMAND_TYPE_METAL_GET_DEVICE_CONTEXT: return "metal_get_device_context";
+
   default: return "unknown";
   }
 }
@@ -108,4 +115,7 @@ static const backend_dispatch_t apir_backend_dispatch_table[APIR_BACKEND_DISPATC
 
   /* backend */
   [APIR_COMMAND_TYPE_BACKEND_GRAPH_COMPUTE] = backend_graph_compute,
+
+  /* metal */
+  [APIR_COMMAND_TYPE_METAL_GET_DEVICE_CONTEXT] = backend_metal_get_device_context,
 };

--- a/ggml/src/ggml-remotingbackend/backend-internal.h
+++ b/ggml/src/ggml-remotingbackend/backend-internal.h
@@ -27,3 +27,8 @@ extern "C" {
 				   char *enc_cur, const char *enc_end,
 				   char **enc_cur_after);
 }
+
+extern void (*ggml_backend_metal_get_device_context_fct)(ggml_backend_dev_t dev,
+							 bool *has_simdgroup_mm,
+							 bool *has_simdgroup_reduction,
+							 bool *use_bfloat);

--- a/ggml/src/ggml-remotingbackend/backend.cpp
+++ b/ggml/src/ggml-remotingbackend/backend.cpp
@@ -14,6 +14,7 @@
 #define GGML_BACKEND_LIBRARY_REG_ENV "APIR_LLAMA_CPP_GGML_LIBRARY_REG"
 #define GGML_BACKEND_LIBRARY_INIT_ENV "APIR_LLAMA_CPP_GGML_LIBRARY_INIT"
 
+#define GGML_BACKEND_LIBRARY_METAL_DEVICE_CONTEXT "ggml_backend_metal_get_device_context"
 
 static void *backend_library_handle = NULL;
 
@@ -86,6 +87,14 @@ extern "C" {
     }
 
     void *ggml_backend_init_fct = dlsym(backend_library_handle, library_init);
+    dlsym_error = dlerror();
+    if (dlsym_error) {
+      ERROR("Cannot load symbol: %s\n", dlsym_error);
+
+      return APIR_BACKEND_INITIALIZE_MISSING_GGML_SYMBOLS;
+    }
+
+    ggml_backend_metal_get_device_context_fct = (void (*)(ggml_backend_dev_t, bool *, bool *, bool *)) dlsym(backend_library_handle, GGML_BACKEND_LIBRARY_METAL_DEVICE_CONTEXT);
     dlsym_error = dlerror();
     if (dlsym_error) {
       ERROR("Cannot load symbol: %s\n", dlsym_error);

--- a/ggml/src/ggml-remotingbackend/shared/apir_backend.h
+++ b/ggml/src/ggml-remotingbackend/shared/apir_backend.h
@@ -9,9 +9,6 @@
 
 #define APIR_BACKEND_FORWARD_INDEX_INVALID 6
 
-// 1 is fast, 0 avoid micro-benchmark crashes
-#define APIR_DEVICE_SUPPORTS_OP_ALWAYS_TRUE 1
-
 // 0 is fast, 1 avoids the backend to crash if an unsupported tensor is received
 #define APIR_BACKEND_CHECK_SUPPORTS_OP 0
 
@@ -57,8 +54,11 @@ typedef enum ApirBackendCommandType {
   /* backend */
   APIR_COMMAND_TYPE_BACKEND_GRAPH_COMPUTE = 19,
 
+  /* metal */
+  APIR_COMMAND_TYPE_METAL_GET_DEVICE_CONTEXT = 20,
+
   // last command_type index + 1
-  APIR_BACKEND_DISPATCH_TABLE_COUNT = 20,
+  APIR_BACKEND_DISPATCH_TABLE_COUNT = 21,
 } ApirBackendCommandType;
 
 

--- a/ggml/src/ggml-remotingfrontend/CMakeLists.txt
+++ b/ggml/src/ggml-remotingfrontend/CMakeLists.txt
@@ -10,6 +10,7 @@ ggml_add_backend_library(ggml-remotingfrontend
                          ggml-backend-reg.cpp
                          ggml-backend-buffer-type.cpp
                          ggml-backend-host-buffer-type.cpp
+                         ggml-metal-remoting.cpp
                          virtgpu.cpp
                          virtgpu-shm.cpp
                          virtgpu-utils.cpp
@@ -17,6 +18,7 @@ ggml_add_backend_library(ggml-remotingfrontend
                          virtgpu-forward-buffer-type.cpp
                          virtgpu-forward-buffer.cpp
                          virtgpu-forward-backend.cpp
+                         virtgpu-forward-metal.cpp
                          virtgpu-forward-impl.h
                          ../../include/ggml-remoting-frontend.h
                          venus_cs_ggml-rpc-front.cpp

--- a/ggml/src/ggml-remotingfrontend/ggml-backend-device.cpp
+++ b/ggml/src/ggml-remotingfrontend/ggml-backend-device.cpp
@@ -44,9 +44,24 @@ ggml_backend_remoting_device_get_memory(ggml_backend_dev_t dev, size_t * free, s
 
 static bool
 ggml_backend_remoting_device_supports_op(ggml_backend_dev_t dev, const ggml_tensor * op) {
+#if USE_ALWAYS_TRUE_SUPPORTS_OP == 1
+  /* ggml-rpc cheats it like this */
+  /* with the current implementation of serialize_tensor, the src/view aren't properly passed */
+  UNUSED(dev);
+  UNUSED(op);
+
+  return true;
+#elif USE_METAL_GUEST_SUPPORTS_OP == 1
+  UNUSED(dev);
+
+  struct ggml_backend_remoting_device_context *device_ctx = GET_DEVICE_CONTEXT();
+
+  return ggml_metal_supports_op(device_ctx->metal_dev_ctx, op);
+#else
   struct virtgpu *gpu = DEV_TO_GPU(dev);
 
   return apir_device_supports_op(gpu, op);
+#endif
 }
 
 static bool

--- a/ggml/src/ggml-remotingfrontend/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-remotingfrontend/ggml-backend-reg.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "ggml-remoting.h"
+#include "ggml-metal-remoting.h"
 
 static struct virtgpu *apir_initialize() {
   static struct virtgpu *apir_gpu_instance = NULL;
@@ -79,11 +80,15 @@ static void ggml_backend_remoting_reg_init_devices(ggml_backend_reg_t reg) {
         ctx->description = desc;
 	ctx->gpu = gpu;
 
-        devices.push_back(new ggml_backend_device {
-            /* .iface   = */ ggml_backend_remoting_device_interface,
-            /* .reg     = */ reg,
-            /* .context = */ ctx,
-          });
+	ggml_backend_dev_t dev = new ggml_backend_device {
+	  /* .iface   = */ ggml_backend_remoting_device_interface,
+	  /* .reg     = */ reg,
+	  /* .context = */ ctx,
+	};
+
+	ctx->metal_dev_ctx = get_metal_dev_context(dev);
+
+        devices.push_back(dev);
       }
       initialized = true;
     }

--- a/ggml/src/ggml-remotingfrontend/ggml-metal-remoting.cpp
+++ b/ggml/src/ggml-remotingfrontend/ggml-metal-remoting.cpp
@@ -1,0 +1,198 @@
+#include "ggml-remoting.h"
+#include "ggml-metal-remoting.h"
+
+const struct ggml_backend_metal_device_context *get_metal_dev_context(const ggml_backend_dev_t dev) {
+  static struct ggml_backend_metal_device_context metal_dev_ctx;
+  static bool has_metal_dev_ctx = false;
+
+  if (has_metal_dev_ctx) {
+    return &metal_dev_ctx;
+  }
+
+  struct virtgpu *gpu = DEV_TO_GPU(dev);
+
+  apir_metal_get_device_context(gpu, &metal_dev_ctx);
+
+  return &metal_dev_ctx;
+}
+
+
+bool ggml_metal_supports_op(const struct ggml_backend_metal_device_context * ctx_dev, const struct ggml_tensor * op) {
+    const bool has_simdgroup_mm        = ctx_dev->has_simdgroup_mm;
+    const bool has_simdgroup_reduction = ctx_dev->has_simdgroup_reduction;
+    const bool use_bfloat              = ctx_dev->use_bfloat;
+
+    if (!use_bfloat) {
+        for (size_t i = 0, n = 3; i < n; ++i) {
+            if (op->src[i] != NULL && op->src[i]->type == GGML_TYPE_BF16) {
+                return false;
+            }
+        }
+    }
+
+    switch (op->op) {
+        case GGML_OP_UNARY:
+            switch (ggml_get_unary_op(op)) {
+                case GGML_UNARY_OP_TANH:
+                case GGML_UNARY_OP_RELU:
+                case GGML_UNARY_OP_SIGMOID:
+                case GGML_UNARY_OP_GELU:
+                case GGML_UNARY_OP_GELU_ERF:
+                case GGML_UNARY_OP_GELU_QUICK:
+                case GGML_UNARY_OP_SILU:
+                case GGML_UNARY_OP_ELU:
+                case GGML_UNARY_OP_NEG:
+                    return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
+                default:
+                    return false;
+            }
+        case GGML_OP_NONE:
+        case GGML_OP_RESHAPE:
+        case GGML_OP_VIEW:
+        case GGML_OP_TRANSPOSE:
+        case GGML_OP_PERMUTE:
+        case GGML_OP_CONCAT:
+            return true;
+        case GGML_OP_ADD:
+        case GGML_OP_SUB:
+        case GGML_OP_MUL:
+        case GGML_OP_DIV:
+            return op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_ACC:
+        case GGML_OP_REPEAT:
+        case GGML_OP_SCALE:
+        case GGML_OP_CONV_TRANSPOSE_1D:
+            return true;
+        case GGML_OP_CLAMP:
+            return op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_SQR:
+        case GGML_OP_SQRT:
+        case GGML_OP_SIN:
+        case GGML_OP_COS:
+            return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_LOG:
+            return false; // TODO: implement
+        case GGML_OP_SUM_ROWS:
+        case GGML_OP_MEAN:
+        case GGML_OP_SOFT_MAX:
+        case GGML_OP_GROUP_NORM:
+            return has_simdgroup_reduction && ggml_is_contiguous(op->src[0]);
+        case GGML_OP_RMS_NORM:
+        case GGML_OP_L2_NORM:
+            return has_simdgroup_reduction && (op->ne[0] % 4 == 0 && ggml_is_contiguous_1(op->src[0]));
+        case GGML_OP_ARGMAX:
+            return true;
+        case GGML_OP_NORM:
+            return has_simdgroup_reduction && (op->ne[0] % 4 == 0 && ggml_is_contiguous_1(op->src[0]));
+        case GGML_OP_ROPE:
+            return true;
+        case GGML_OP_IM2COL:
+            return op->src[0]->type == GGML_TYPE_F16;
+        case GGML_OP_POOL_1D:
+            return false;
+        case GGML_OP_UPSCALE:
+            return op->src[0]->type == GGML_TYPE_F32 && op->op_params[0] == GGML_SCALE_MODE_NEAREST;
+        case GGML_OP_POOL_2D:
+        case GGML_OP_PAD:
+        case GGML_OP_PAD_REFLECT_1D:
+        case GGML_OP_TIMESTEP_EMBEDDING:
+        case GGML_OP_ARGSORT:
+        case GGML_OP_LEAKY_RELU:
+            return op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_ARANGE:
+            return true;
+        case GGML_OP_FLASH_ATTN_EXT:
+            if (op->src[0]->ne[0] == 32) {
+                // head size == 32 (e.g. bert-bge-small)
+                // TODO: not sure if it is worth adding kernels for this size
+                return false;
+            }
+            if (op->src[0]->ne[0] == 576) {
+                // DeepSeek sizes
+                // TODO: disabled for now, until optmized
+                return false;
+            }
+            if (op->src[1]->type != op->src[2]->type) {
+                return false;
+            }
+            return has_simdgroup_mm; // TODO: over-restricted for vec-kernels
+        case GGML_OP_SSM_CONV:
+        case GGML_OP_SSM_SCAN:
+        case GGML_OP_RWKV_WKV6:
+        case GGML_OP_RWKV_WKV7:
+            return true;
+        case GGML_OP_MUL_MAT:
+        case GGML_OP_MUL_MAT_ID:
+            return has_simdgroup_reduction &&
+                (op->src[0]->type != GGML_TYPE_F32 || op->src[1]->type == GGML_TYPE_F32);
+        case GGML_OP_CPY:
+        case GGML_OP_DUP:
+        case GGML_OP_CONT:
+            {
+                switch (op->src[0]->type) {
+                    case GGML_TYPE_F32:
+                        switch (op->type) {
+                           case GGML_TYPE_F32:
+                           case GGML_TYPE_F16:
+                           case GGML_TYPE_BF16:
+                           case GGML_TYPE_Q8_0:
+                           case GGML_TYPE_Q4_0:
+                           case GGML_TYPE_Q4_1:
+                           case GGML_TYPE_Q5_0:
+                           case GGML_TYPE_Q5_1:
+                           case GGML_TYPE_IQ4_NL:
+                                return true;
+                           default:
+                                return false;
+                        }
+                    case GGML_TYPE_F16:
+                        switch (op->type) {
+                            case GGML_TYPE_F32:
+                            case GGML_TYPE_F16:
+                                return true;
+                            default:
+                                return false;
+                        }
+                    case GGML_TYPE_BF16:
+                        switch (op->type) {
+                            case GGML_TYPE_F32:
+                            case GGML_TYPE_BF16:
+                                return true;
+                            default:
+                                return false;
+                        }
+                    case GGML_TYPE_Q4_0:
+                    case GGML_TYPE_Q4_1:
+                    case GGML_TYPE_Q5_0:
+                    case GGML_TYPE_Q5_1:
+                    case GGML_TYPE_Q8_0:
+                        switch (op->type) {
+                            case GGML_TYPE_F32:
+                            case GGML_TYPE_F16:
+                                return true;
+                            default:
+                                return false;
+                        }
+                    default:
+                        return false;
+                };
+            }
+        case GGML_OP_SET:
+            {
+                switch (op->src[0]->type) {
+                    case GGML_TYPE_F32:
+                    case GGML_TYPE_I32:
+                        return true;
+                    default:
+                        return false;
+                };
+            }
+        case GGML_OP_DIAG_MASK_INF:
+        case GGML_OP_GET_ROWS:
+            {
+                return op->ne[3] == 1;
+            }
+        default:
+            return false;
+    }
+}

--- a/ggml/src/ggml-remotingfrontend/ggml-metal-remoting.h
+++ b/ggml/src/ggml-remotingfrontend/ggml-metal-remoting.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "ggml-impl.h"
+#include "ggml-backend-impl.h"
+#include "ggml-backend.h"
+
+struct ggml_backend_metal_device_context {
+  bool has_simdgroup_mm;
+  bool has_simdgroup_reduction;
+  bool use_bfloat;
+};
+
+
+const struct ggml_backend_metal_device_context *get_metal_dev_context(const ggml_backend_dev_t dev);
+
+bool ggml_metal_supports_op(const struct ggml_backend_metal_device_context * ctx_dev, const struct ggml_tensor * op);

--- a/ggml/src/ggml-remotingfrontend/ggml-remoting.h
+++ b/ggml/src/ggml-remotingfrontend/ggml-remoting.h
@@ -8,7 +8,13 @@
 #include "ggml-impl.h"
 #include "ggml-backend-impl.h"
 #include "ggml-backend.h"
+#include "ggml-metal-remoting.h"
 #include "virtgpu.h"
+
+
+// 1 is fast, 0 avoid micro-benchmark crashes
+#define USE_ALWAYS_TRUE_SUPPORTS_OP 0
+#define USE_METAL_GUEST_SUPPORTS_OP 1
 
 #define DEV_TO_GPU(name) \
   ((struct ggml_backend_remoting_device_context *) (name)->context)->gpu
@@ -23,7 +29,7 @@
   ((struct ggml_backend_remoting_buffer_context *) (name)->context)->apir_context.host_handle
 
 #define GET_DEVICE_CONTEXT() \
-  (struct ggml_backend_remoting_device_context *) ggml_backend_remoting_get_device(0)->context \
+  (struct ggml_backend_remoting_device_context *) ggml_backend_remoting_get_device(0)->context
 
 static inline apir_buffer_type_host_handle_t
 ggml_buffer_type_to_apir_handle(ggml_backend_buffer_type_t buft) {
@@ -85,6 +91,8 @@ struct ggml_backend_remoting_device_context {
   std::vector<std::tuple<void*, size_t, struct vn_renderer_shmem *>> shared_memory;
 
   struct virtgpu *gpu;
+
+  const struct ggml_backend_metal_device_context *metal_dev_ctx;
 };
 
 struct ggml_backend_remoting_buffer_context {

--- a/ggml/src/ggml-remotingfrontend/virtgpu-forward-buffer.cpp
+++ b/ggml/src/ggml-remotingfrontend/virtgpu-forward-buffer.cpp
@@ -16,8 +16,6 @@ apir_buffer_get_base(struct virtgpu *gpu, apir_buffer_context_t *buffer_context)
 
   REMOTE_CALL_FINISH(gpu, encoder, decoder);
 
-  //INFO("%s: received base %p\n", __func__,  (void *) base);
-
   return (void *) base;
 }
 

--- a/ggml/src/ggml-remotingfrontend/virtgpu-forward-device.cpp
+++ b/ggml/src/ggml-remotingfrontend/virtgpu-forward-device.cpp
@@ -135,14 +135,6 @@ apir_device_get_memory(struct virtgpu *gpu, size_t *free, size_t *total) {
 
 bool
 apir_device_supports_op(struct virtgpu *gpu, const ggml_tensor *op) {
-#if APIR_DEVICE_SUPPORTS_OP_ALWAYS_TRUE
-  /* ggml-rpc cheats it like this */
-  /* with the current implementation of serialize_tensor, the src/view aren't properly passed */
-  UNUSED(gpu);
-  UNUSED(op);
-
-  return true;
-#else
   struct vn_cs_encoder *encoder;
   struct vn_cs_decoder *decoder;
   REMOTE_CALL_PREPARE(gpu, encoder, APIR_COMMAND_TYPE_DEVICE_SUPPORTS_OP);
@@ -157,7 +149,6 @@ apir_device_supports_op(struct virtgpu *gpu, const ggml_tensor *op) {
   REMOTE_CALL_FINISH(gpu, encoder, decoder);
 
   return supports_op;
-#endif
 }
 
 apir_buffer_type_host_handle_t

--- a/ggml/src/ggml-remotingfrontend/virtgpu-forward-metal.cpp
+++ b/ggml/src/ggml-remotingfrontend/virtgpu-forward-metal.cpp
@@ -1,0 +1,19 @@
+#include "virtgpu-forward-impl.h"
+
+bool
+apir_metal_get_device_context(struct virtgpu *gpu, struct ggml_backend_metal_device_context *metal_dev_ctx) {
+  struct vn_cs_encoder *encoder;
+  struct vn_cs_decoder *decoder;
+
+  REMOTE_CALL_PREPARE(gpu, encoder, APIR_COMMAND_TYPE_METAL_GET_DEVICE_CONTEXT);
+
+  REMOTE_CALL(gpu, encoder, decoder);
+
+  vn_decode_bool_t(decoder, &metal_dev_ctx->has_simdgroup_mm);
+  vn_decode_bool_t(decoder, &metal_dev_ctx->has_simdgroup_reduction);
+  vn_decode_bool_t(decoder, &metal_dev_ctx->use_bfloat);
+
+  REMOTE_CALL_FINISH(gpu, encoder, decoder);
+
+  return true;
+}

--- a/ggml/src/ggml-remotingfrontend/virtgpu-forward.h
+++ b/ggml/src/ggml-remotingfrontend/virtgpu-forward.h
@@ -44,3 +44,7 @@ void apir_buffer_free_buffer(struct virtgpu *gpu, apir_buffer_context_t *buffer_
 /* backend */
 
 ggml_status apir_backend_graph_compute(struct virtgpu *gpu, ggml_cgraph *cgraph);
+
+/* metal */
+
+bool apir_metal_get_device_context(struct virtgpu *gpu, struct ggml_backend_metal_device_context *metal_dev_ctx);


### PR DESCRIPTION
required for running `test-backend-ops perf`, but slow if running in the host

Closing #10 